### PR TITLE
docs: add basic AsFormData example (draft)

### DIFF
--- a/README.md
+++ b/README.md
@@ -810,3 +810,9 @@ Or you can just run it with one click [on StackBlitz](https://stackblitz.com/~/g
 
 Built on 🌎 with ✍️, 🧠 and a bit of 🤖
 
+## AsFormData (Draft Docs)
+
+Basic example of binding form data to a stream:
+
+```js
+import { AsFormData } from "rimmel";

--- a/examples/asformdata-basic.js
+++ b/examples/asformdata-basic.js
@@ -1,0 +1,27 @@
+// Example: Basic usage of AsFormData with Rimmel
+// This is just a placeholder demo for docs — will expand later
+
+import { rml, AsFormData, JSONDump } from 'rimmel';
+import { Subject } from 'rxjs';
+
+// Create a stream to collect form data
+const formDataStream = new Subject();
+
+document.body.innerHTML = rml`
+  <form onsubmit="${AsFormData(formDataStream)}">
+    <label>
+      Name:
+      <input name="name" required>
+    </label>
+    <br>
+    <label>
+      Email:
+      <input name="email" type="email" required>
+    </label>
+    <br>
+    <button type="submit">Submit</button>
+  </form>
+
+  <h3>Form Output:</h3>
+  <div>${JSONDump(formDataStream)}</div>
+`;


### PR DESCRIPTION
I'[m Sorrry for the inconvenience 
I created this new pull request because the previous one (#17 ) was closed by mistake and I was unable to reopen it. All changes from the previous PR are included here.

I have done what you had told m to do i have squashed my comment into single commit
<img width="1386" height="436" alt="Screenshot 2025-09-20 202140" src="https://github.com/user-attachments/assets/2d483568-b17d-4b47-870a-826154c32229" />


### What’s New
- Started documentation + examples for **AsFormData** and **AsTypedFormData**
- Initial placeholders for typed inputs (number, date, checkbox)

### Why Draft?
- This is just the starting point to get feedback before adding full examples & validation
- Once agreed, I’ll extend with complete docs and typed input support

### Next Steps
- Add runnable examples
- Expand docs with typed inputs
- Explore validation helpers (separate issue/PR)
- 
Please let me know if you have any questions or feedback