### PR TITLE
test(schedulers): add BDD-style unit tests with deterministic RAF/time helper

### DIFF
--- a/src/schedulers/adaptive-animation-frame.test.ts
+++ b/src/schedulers/adaptive-animation-frame.test.ts
@@ -1,0 +1,46 @@
+import scheduler from './adaptive-animation-frame';
+import { MockElement } from '../test-support';
+import { installFakeRAF } from './test-support-raf';
+
+describe('AdaptiveAnimationFrame Scheduler', () => {
+  let raf = installFakeRAF();
+
+  beforeEach(() => {
+    raf = installFakeRAF();
+  });
+
+  afterEach(() => {
+    raf.restore();
+  });
+
+  describe('Given multiple heavy tasks in one tick', () => {
+    it('spreads work across multiple frames based on budget', () => {
+      const nodeA = MockElement();
+      const nodeB = MockElement();
+      const nodeC = MockElement();
+
+      const calls: string[] = [];
+
+      const scheduleA = scheduler(nodeA as unknown as Node, () => { calls.push('A'); raf.advance(10); });
+      const scheduleB = scheduler(nodeB as unknown as Node, () => { calls.push('B'); raf.advance(10); });
+      const scheduleC = scheduler(nodeC as unknown as Node, () => { calls.push('C'); raf.advance(10); });
+
+      scheduleA();
+      scheduleB();
+      scheduleC();
+
+      expect(calls).toEqual([]);
+      expect(raf.scheduledCount()).toBe(1);
+
+      raf.runFrame();
+      expect(calls).toEqual(['A']);
+
+      raf.runFrame();
+      expect(calls).toEqual(['A', 'B']);
+
+      raf.runFrame();
+      expect(calls).toEqual(['A', 'B', 'C']);
+      expect(raf.pending()).toBe(0);
+    });
+  });
+});

--- a/src/schedulers/animation-frame-by-node.test.ts
+++ b/src/schedulers/animation-frame-by-node.test.ts
@@ -1,0 +1,42 @@
+import scheduler from './animation-frame-by-node';
+import { MockElement } from '../test-support';
+import { installFakeRAF } from './test-support-raf';
+
+describe('AnimationFrameByNode Scheduler', () => {
+  let raf = installFakeRAF();
+
+  beforeEach(() => {
+    raf = installFakeRAF();
+  });
+
+  afterEach(() => {
+    raf.restore();
+  });
+
+  describe('Given multiple tasks for the same node in one tick', () => {
+    it('debounces per node, running only the latest per node', () => {
+      const nodeA = MockElement();
+      const nodeB = MockElement();
+
+      const calls: Array<[string, number]> = [];
+
+      const scheduleA = scheduler(nodeA as unknown as Node, (v?: number) => { if (typeof v === 'number') calls.push(['A', v]); });
+      const scheduleB = scheduler(nodeB as unknown as Node, (v?: number) => { if (typeof v === 'number') calls.push(['B', v]); });
+
+      scheduleA(1);
+      scheduleA(2);
+      scheduleB(3);
+
+      expect(calls.length).toBe(0);
+      expect(raf.scheduledCount()).toBe(1);
+
+      raf.runFrame();
+
+      expect(calls).toEqual([
+        ['A', 2],
+        ['B', 3],
+      ]);
+      expect(raf.pending()).toBe(0);
+    });
+  });
+});

--- a/src/schedulers/animation-frame.test.ts
+++ b/src/schedulers/animation-frame.test.ts
@@ -1,0 +1,36 @@
+import scheduler from './animation-frame';
+import { MockElement } from '../test-support';
+import { installFakeRAF } from './test-support-raf';
+
+describe('AnimationFrame Scheduler', () => {
+  let raf = installFakeRAF();
+
+  beforeEach(() => {
+    raf = installFakeRAF();
+  });
+
+  afterEach(() => {
+    raf.restore();
+  });
+
+  describe('Given multiple tasks in the same tick', () => {
+    it('renders them together on the next frame (single RAF)', () => {
+      const node = MockElement();
+      const calls: number[] = [];
+
+      const task = (x?: number) => { if (typeof x === 'number') calls.push(x); };
+      const schedule = scheduler(node as unknown as Node, task);
+
+      schedule(1);
+      schedule(2);
+
+      expect(calls.length).toBe(0);
+      expect(raf.scheduledCount()).toBe(1);
+
+      raf.runFrame();
+
+      expect(calls).toEqual([1, 2]);
+      expect(raf.pending()).toBe(0);
+    });
+  });
+});

--- a/src/schedulers/ema-animation-frame.test.ts
+++ b/src/schedulers/ema-animation-frame.test.ts
@@ -1,0 +1,51 @@
+import scheduler from './ema-animation-frame';
+import { MockElement } from '../test-support';
+import { installFakeRAF } from './test-support-raf';
+
+describe('EMA AnimationFrame Scheduler', () => {
+  let raf = installFakeRAF();
+
+  beforeEach(() => {
+    raf = installFakeRAF();
+  });
+
+  afterEach(() => {
+    raf.restore();
+  });
+
+  describe('Given heavy tasks relative to frame budget', () => {
+    it('reschedules remaining work across subsequent frames', () => {
+      const nodeA = MockElement();
+      const nodeB = MockElement();
+      const nodeC = MockElement();
+
+      const calls: string[] = [];
+
+      const heavy = (label: string) => () => { calls.push(label); raf.advance(20); };
+
+      const scheduleA = scheduler(nodeA as unknown as Node, heavy('A'));
+      const scheduleB = scheduler(nodeB as unknown as Node, heavy('B'));
+      const scheduleC = scheduler(nodeC as unknown as Node, heavy('C'));
+
+      scheduleA();
+      scheduleB();
+      scheduleC();
+
+      expect(calls).toEqual([]);
+      expect(raf.scheduledCount()).toBe(1);
+
+      // First frame should process only the first heavy task
+      raf.runFrame();
+      expect(calls).toEqual(['A']);
+
+      // Second frame: next heavy task
+      raf.runFrame();
+      expect(calls).toEqual(['A', 'B']);
+
+      // Third frame: last heavy task
+      raf.runFrame();
+      expect(calls).toEqual(['A', 'B', 'C']);
+      expect(raf.pending()).toBe(0);
+    });
+  });
+});

--- a/src/schedulers/test-support-raf.ts
+++ b/src/schedulers/test-support-raf.ts
@@ -1,0 +1,72 @@
+export type FakeRAF = {
+  runFrame: () => void;
+  runFrames: (n: number) => void;
+  advance: (ms: number) => void;
+  setNow: (ms: number) => void;
+  now: () => number;
+  pending: () => number;
+  scheduledCount: () => number;
+  restore: () => void;
+};
+
+/**
+ * Installs a fake requestAnimationFrame + performance.now controller
+ * so we can deterministically step frames and time in tests.
+ */
+export function installFakeRAF(): FakeRAF {
+  const originalRAF = globalThis.requestAnimationFrame as any;
+  const originalPerf = globalThis.performance as any;
+  const originalNow = originalPerf?.now?.bind(originalPerf) ?? (() => 0);
+
+  // Ensure performance exists
+  if (!globalThis.performance) {
+    (globalThis as any).performance = {} as any;
+  }
+
+  let now = 0;
+  const queue: FrameRequestCallback[] = [];
+  let scheduled = 0;
+
+  // Replace requestAnimationFrame to enqueue callbacks
+  (globalThis as any).requestAnimationFrame = (cb: FrameRequestCallback): number => {
+    queue.push(cb);
+    scheduled++;
+    return scheduled;
+  };
+
+  // Replace performance.now
+  (globalThis.performance as any).now = () => now;
+
+  const runFrame = () => {
+    // Execute callbacks scheduled for this frame. New callbacks get queued for next frame.
+    const callbacks = queue.splice(0, queue.length);
+    for (const cb of callbacks) {
+      cb(now as unknown as DOMHighResTimeStamp);
+    }
+  };
+
+  const runFrames = (n: number) => {
+    for (let i = 0; i < n; i++) runFrame();
+  };
+
+  const pending = () => queue.length;
+  const setNow = (ms: number) => { now = ms; };
+  const advance = (ms: number) => { now += ms; };
+
+  const restore = () => {
+    if (originalRAF) {
+      (globalThis as any).requestAnimationFrame = originalRAF;
+    } else {
+      delete (globalThis as any).requestAnimationFrame;
+    }
+    if (originalPerf) {
+      (globalThis as any).performance = originalPerf;
+      if (originalPerf.now) (globalThis.performance as any).now = originalNow;
+    } else {
+      delete (globalThis as any).performance;
+    }
+  };
+
+  return { runFrame, runFrames, advance, setNow, now: () => now, pending, scheduledCount: () => scheduled, restore };
+}
+


### PR DESCRIPTION
Summary

  - Adds per-scheduler BDD tests mirroring existing sources/sinks structure.
  - Introduces a small helper to mock requestAnimationFrame and performance.now for deterministic, elegant tests.
  - Aligns to repo’s global Bun test style (no explicit imports).

  Scope

  - New tests:
      - src/schedulers/animation-frame.test.ts
      - src/schedulers/animation-frame-by-node.test.ts
      - src/schedulers/adaptive-animation-frame.test.ts
      - src/schedulers/ema-animation-frame.test.ts
  - Test helper:
      - src/schedulers/test-support-raf.ts

  Behavior Covered

  - animation-frame: batches multiple tasks in the same tick to run on the next frame (single RAF).
  - animation-frame-by-node: debounces per-node, runs latest per node.
  - adaptive-animation-frame: spreads heavy tasks across multiple frames under a 16ms budget.
  - ema-animation-frame: uses an EMA-based approach to enforce frame budgets and reschedule remaining tasks.

  Why

  - Addresses “Unit tests for Schedulers #27”.
  - Establishes a minimal test architecture for schedulers so future tests are easy to write and maintain.

  How To Test

  - Only the scheduler tests: bun test src/schedulers/*.test.ts