### PR TITLE
Fix GitHub Actions bundle/jekyll setup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,8 +18,20 @@ jobs:
         with:
           node-version: 22
 
-      - name: Install dependencies
-        run: npm ci # Or the appropriate command to install dependencies
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+          working-directory: docs
+
+      - name: Install Node.js dependencies
+        run: npm ci
+
+      - name: Install Jekyll dependencies
+        run: |
+          cd docs
+          bundle install
 
       - name: Build the library
         run: npm run build


### PR DESCRIPTION
## Problem
GitHub Actions workflow was failing because `bundle exec jekyll` command couldn't find bundle/jekyll dependencies in the CI environment.

## Solution
- ✅ Added Ruby setup step with version 3.1
- ✅ Added bundler cache for faster builds
- ✅ Added explicit `bundle install` step in docs directory
- ✅ Ensured proper dependency installation order

## Changes
- Added `ruby/setup-ruby@v1` action
- Added Jekyll dependency installation step
- Improved workflow structure for better reliability

Fixes #50