### PR TITLE
fix: ensure initial class object renders correctly

### DIFF
--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -237,7 +237,7 @@ export function rml(strings: TemplateStringsArray, ...expressions: RMLTemplateEx
 						;
 						const formattedInitial = stringifyInitialValue(initialValue, attributeName);
 
-						acc = (prefix + (formattedInitial ?? '')).replace(/<(\w[\w-]*)\s+([^>]+)$/, `<$1 ${existingRef?'':`${RESOLVE_ATTRIBUTE}="${ref}" `}$2`);
+						acc = (prefix + formattedInitial).replace(/<(\w[\w-]*)\s+([^>]+)$/, `<$1 ${existingRef?'':`${RESOLVE_ATTRIBUTE}="${ref}" `}$2`);
 					}
 				} else if(/<[a-z_][a-z0-9_-]*[^>]*(?:\s+\.\.\.)?$/ig.test(accPlusString.substring(lastTag))) {
 


### PR DESCRIPTION
Ensure initial render of class bindings derived from BehaviorSubject objects converts objects (e.g. { dotted: true }) into proper class strings ('dotted') instead of [object Object].
Issue: #65