### PR TITLE
refactor: use addListener() in eventListnerSource and EventHandlerSink (#61)

### DIFF
--- a/src/sinks/event-handler-sink.ts
+++ b/src/sinks/event-handler-sink.ts
@@ -1,11 +1,7 @@
-import type { HTMLEventName } from "../types/dom";
+import { addListener } from "../lib/addListener";
+import type { RMLEventListener, HTMLEventName } from "../types/dom";
 import type { Sink } from "../types/sink";
 
 export const EventHandlerSink: Sink<HTMLElement> = (node: HTMLElement, e: HTMLEventName) =>
-	// FIXME: wrap h and options in an object, as nothing will emit both values!
-	// TODO: use addListener() instead of this
-	(h: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions) => {
-		node.addEventListener(e, h, options);
-		// ? node.removeEventListener(e, h) // FIXME: to be able to remove an event listener, will need to store a reference to it first!
-		// : node.addEventListener(e, h)
-	};
+    (handler: RMLEventListener, options?: AddEventListenerOptions) =>
+        addListener(node, e, handler, options);

--- a/src/sources/event-listener.ts
+++ b/src/sources/event-listener.ts
@@ -1,9 +1,11 @@
-import { HTMLEventName } from "../types/dom"
+import { addListener } from "../lib/addListener";
+import type { RMLEventListener, HTMLEventName } from "../types/dom";
 
-const options = { }; // TODO: define better
-
-// TODO: use addListener() instead of this
-export const eventListnerSource =
-	(node: HTMLElement, eventName: HTMLEventName, handler: EventListenerOrEventListenerObject) =>
-		node.addEventListener(eventName, handler, options)
-;
+export const eventListnerSource = (
+  node: HTMLElement,
+  eventName: HTMLEventName,
+  handler: RMLEventListener,
+  options?: AddEventListenerOptions
+) => {
+  return addListener(node, eventName, handler, options);
+};


### PR DESCRIPTION
### Summary #61 
This PR refactors both `event-listener.ts` and `event-handler-sink.ts` to use the centralized `addListener()` utility for consistent and type-safe event handling.

### Changes Made
- Imported `addListener` from `../lib/addListener`
- Replaced direct `addEventListener()` calls with `addListener()`
- Updated handler type to `RMLEventListener`
- Added optional `options` parameter for flexibility
- Removed old `TODO` and `FIXME` comments

### Benefits
- ✅ Improves type safety with `RMLEventListener`
- ✅ Cleans up 2 TODOs and 1 FIXME
- ✅ Adds consistency in event listener management
- ✅ Enables DOM Observables and mount event support
- ✅ Makes the code cleaner and easier to maintain

### Verification
- [x] Code builds successfully (`npm run build`)
- [x] All tests pass (`npm test`)
- [x] Verified event listeners trigger correctly in tests
